### PR TITLE
Fix compatibility with redmine_sudo plugin

### DIFF
--- a/app/models/oidc_session.rb
+++ b/app/models/oidc_session.rb
@@ -92,6 +92,7 @@ class OidcSession
 
   def user_attributes
     attributes = decoded_id_token.raw_attributes
+    admin_key = Redmine::Plugin.installed?(:redmine_sudo) ? :sudoer : :admin
     {
       oidc_identifier: oidc_identifier,
       login: attributes['preferred_username'],
@@ -99,7 +100,7 @@ class OidcSession
       lastname: attributes['family_name'],
       mail: attributes['email'],
       avatar_url: attributes['picture'],
-      admin: roles.include?(admin_role),
+      "#{admin_key}": roles.include?(admin_role),
     }
   end
 


### PR DESCRIPTION
The redmine_sudo plugin toggles the admin attribute when the user (de)activates the Administrator (sudo) mode. It adds a new attribute 'sudoer' which controls if the user is allowed to become an admin.