### PR TITLE
Fix #require_login - return true when user is logged

### DIFF
--- a/lib/redmine_oidc/application_controller_patch.rb
+++ b/lib/redmine_oidc/application_controller_patch.rb
@@ -31,6 +31,8 @@ module RedmineOidc
         redirect_to oidc_login_path(back_url: url)
         return false
       end
+
+      true
     end
 
     def session_expired?


### PR DESCRIPTION
The original ApplicationController#require_login method returns true when the user is logged in, we should do the same.